### PR TITLE
Update FormatPilatusHelpers.py (determine_pilatus_mask)

### DIFF
--- a/src/dxtbx/format/FormatPilatusHelpers.py
+++ b/src/dxtbx/format/FormatPilatusHelpers.py
@@ -144,8 +144,10 @@ def determine_pilatus_mask(xdetector):
 
     size = xdetector[0].get_image_size()
 
-    # Hardcoded module size and gap size
-    detector = _DetectorDatabase["Pilatus"]
+    # get detector class based on size (an image might look like a Pilatus
+    # image, but could be Eiger or Eiger2 after all: the size usually tells
+    # us exactly which it is)
+    detector = _get_pad_module_gap(xdetector)
 
     # Edge dead areas not included, only gaps between modules matter
     n_fast, remainder = divmod(size[0], detector.module_size_fast)


### PR DESCRIPTION
Instead of hard-wiring the Pilatus module/gap model, use the detector size to get the correct PAD type (Pilatus, Eiger or Eiger2).

Without this change, one can't e.g. "dials.import" images where the detector identifier (# Detector: item in mini-cbf file) doesn't contain a known string like "EIGER2". Relying on such a string to determine PAD type seems unnecessary when the detector size uniquely defines Pilatus, Eiger and Eiger2 detectors.